### PR TITLE
fixed scroll position issue

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,4 @@
+exports.shouldUpdateScroll = () => {
+  window.scrollTo(0, 0)
+  return false
+}

--- a/src/styles/hackers.css
+++ b/src/styles/hackers.css
@@ -4,7 +4,6 @@ body,
 #___gatsby,
 #gatsby-focus-wrapper {
     width: 100%;
-    height: 100%;
     min-height: 100% !important;
     margin: 0px;
     padding: 0px;

--- a/src/styles/home.css
+++ b/src/styles/home.css
@@ -2,7 +2,6 @@
 html,
 body {
   width: 100%;
-  height: 100%;
   margin: 0px;
   padding: 0px;
   overflow-x: hidden;


### PR DESCRIPTION
Added gatsby-browser.js file that resets the scroll position every time the page changes, needed to remove height: 100% from CSS in order for scrollTo(0, 0) to work.